### PR TITLE
bitbake: support for new override syntax

### DIFF
--- a/bitbake.py
+++ b/bitbake.py
@@ -50,7 +50,7 @@ class BitbakeLexer(RegexLexer):
 
         'variable-definition': [
             (r'^(export)?(\s*)'                         # export
-             r'([\w.+/-]+(?:_[${}\w.+/-]+)?)'           # FILES_${PN}-dev
+             r'([\w.+/-]+(?:[:_][${}\w.+/-]+)?)'           # FILES_${PN}-dev
              r'(?:(\[)([\w.+/-]+)(\]))*(\s*)'           # [md5sum]
              r'([:+.]=|=[+.]|\?\??=|=)(\s*)',           # += 
                 bygroups(Keyword.Type, Text, 


### PR DESCRIPTION
map it all to variable definition.
This allows parsing new override syntax (effective since kirkstone release) along the original syntax